### PR TITLE
undefinedする件を修正

### DIFF
--- a/src/components/config/Slider.js
+++ b/src/components/config/Slider.js
@@ -36,8 +36,8 @@ const CustomizedSlider = props => {
   const classes = useStyles();
 
   const onChangeHandler = (event, value) => {
-    const parameterTitle = event.target.parentElement.dataset.parameterTitle;
-    const actionType = event.target.parentElement.dataset.actionType;
+    const parameterTitle = props.parameterTitle;
+    const actionType = props.actionType;
 
     if (parameterTitle === undefined || actionType === undefined) {
       console.log('Error: undefined!');


### PR DESCRIPTION
React童貞なんで間違っているかもしれませんが・・・

event発火時に「parentElement」が消えてしまうようなので
（レンダータイミングの問題？）
取得先をpropsに変更してみました
